### PR TITLE
Update terms.py

### DIFF
--- a/analyst_sheets/terms.py
+++ b/analyst_sheets/terms.py
@@ -10,7 +10,7 @@ KEY_TERMS = (
     'certainty',
     'clean energy',
     'climate',
-    'climate',
+    'climate change',
     'compliance',
     'cost-effective',
     'costs',
@@ -18,7 +18,7 @@ KEY_TERMS = (
     'deia',
     'deregulatory',
     'disadvantaged',
-    'diversity'
+    'diversity',
     'droughts',
     'economic certainty',
     'economic impacts',


### PR DESCRIPTION
Missing a comma between 'diversity' and 'droughts' so that I think it gets read as 'diversitydroughts' which is perhaps where we're headed but I think it means unexpected/missing key terms changed results.

Also, I think there were two instances of 'climate' I assume one is meant to be 'climate change'