### PR TITLE
Add some Spanish key terms (and handle accents better)

### DIFF
--- a/analyst_sheets/normalize.py
+++ b/analyst_sheets/normalize.py
@@ -11,6 +11,7 @@ import html5_parser
 import re
 import soupsieve
 from surt import surt
+import unicodedata
 from urllib.parse import parse_qs, urlencode, urljoin
 
 
@@ -18,10 +19,21 @@ INFIX_PUNCTUATION = re.compile(r'''['‘’]''')
 NON_WORDS = re.compile(r'\W+')
 
 
+def remove_accents(text: str) -> str:
+    """
+    Remove all the accent characters in a unicode string.
+    """
+    clean = ''.join(
+        c for c in unicodedata.normalize('NFD', text)
+        if not unicodedata.combining(c)
+    )
+    return unicodedata.normalize('NFKC', clean)
+
+
 def normalize_text(text):
     """
     Normalize a chunk of text from an HTML document by casefolding and removing
-    punctuation.
+    punctuation and accents/combining marks.
     """
     # Remove punctuation between words
     return NON_WORDS.sub(
@@ -30,7 +42,7 @@ def normalize_text(text):
         INFIX_PUNCTUATION.sub(
             '',
             # Lower-case and normalize unicode characters
-            text.casefold()
+            remove_accents(text).casefold()
         )
     )
 

--- a/analyst_sheets/terms.py
+++ b/analyst_sheets/terms.py
@@ -87,6 +87,11 @@ KEY_TERMS = (
     'underserved',
     'water quality',
     'wildfires',
+
+    # Español
+    'clima',
+    'climática',
+    'climático',
 )
 
 # Ensure key terms are normalized in the same way as our text will be.

--- a/analyst_sheets/terms.py
+++ b/analyst_sheets/terms.py
@@ -1,3 +1,5 @@
+from .normalize import normalize_text
+
 KEY_TERMS = (
     'adaptation',
     'agency mission',
@@ -86,5 +88,8 @@ KEY_TERMS = (
     'water quality',
     'wildfires',
 )
+
+# Ensure key terms are normalized in the same way as our text will be.
+KEY_TERMS = list(set(normalize_text(term) for term in KEY_TERMS))
 
 KEY_TERM_GRAMS = max((len(term.split(' ')) for term in KEY_TERMS))


### PR DESCRIPTION
I realized yesterday that we are probably not surfacing some important changes to Spanish pages (now that we are tracking a handful) because we don’t have a Spanish version of any of our key terms. This adds a few (we should probably just translate them all).

Doing so revealed that we were not necessarily handling accents very well or very reliably, so I’ve also added code to:
1. Always compare a Unicode normalized form (NFKC in this case).
2. Remove accents from the text for comparison purposes. I think this is probably the right thing (much looser matching), but we could drop this part. It’s not as critical as the unicode normalization.