### PR TITLE
Consider Cloudflare challenges to be bad captures

### DIFF
--- a/generate_task_sheets.py
+++ b/generate_task_sheets.py
@@ -152,6 +152,9 @@ def maybe_bad_capture(version) -> bool:
             return True
         elif cache_error:
             return True
+    elif server == 'cloudflare':
+        if headers.get('cf-mitigated', '').lower() == 'challenge':
+            return True
     # TODO: see if we have any Azure CDN examples?
     # TODO: More general heuristics?
     # else:


### PR DESCRIPTION
We hit a lot of Cloudflare challenges on ehp.niehs.nih.gov last month that caused problems and hit them occasionally on other sites. Like AWS WAF challenges, these are not really good/valid/legitimate captures that should be considered as changed content. This adds heuristics for them to the `maybe_bad_capture()` method so we don’t use them in changes.

For more on the Cloudflare challenges, see:
- https://github.com/edgi-govdata-archiving/web-monitoring/issues/189
- https://github.com/edgi-govdata-archiving/web-monitoring-crawler/issues/32