### PR TITLE
Debug analyze workflow inputs

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -67,6 +67,8 @@ jobs:
           echo 'false == 1? ${{ false == 1 && 'yep' || 'nope' }}'
           echo 'true == 0? ${{ true == 0 && 'yep' || 'nope' }}'
           echo 'true == 1? ${{ true == 1 && 'yep' || 'nope' }}'
+          echo ''
+          echo '(inputs.readability || toJSON(inputs.readability) == 'null')? ${{ (inputs.readability || toJSON(inputs.readability) == 'null') && 'true' || 'false' }}'
 
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
This is just a test PR meant to debug what’s going on with inputs (see https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets/issues/9#issuecomment-3706505414). Encountered some surprise behavior with the analyze workflow in #48.

The way workflow inputs are functioning seems to have changed. This adds some logging to help debug.