### PR TITLE
Correctly default readability to true

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -52,7 +52,7 @@ jobs:
       DEFAULT_THRESHOLD: '0.25'
       DEFAULT_FROM: ${{ github.event_name == 'schedule' && '268' || '240' }}
       DEFAULT_TO: '0'
-      USE_READABILITY: ${{ inputs.readability == false && 'false' || 'true' }}
+      USE_READABILITY: ${{ (inputs.readability || toJSON(inputs.readability) == 'null') && 'true' || 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Ensure `USE_READABILITY` is `"true"` by default in GH actions. I’m pretty sure the old code used to have this effect, but some subtle change in type casting behavior altered it (see https://github.com/edgi-govdata-archiving/web-monitoring-task-sheets/issues/9#issuecomment-3706505414 and #49).