### PR TITLE
Add PRs to project on `pull_request_target`

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,7 +6,7 @@ on:
       - opened
       - reopened
       - transferred
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
It was a mistake that the `add-to-project` workflow was originally set up on the `pull_request` event, which does not have access to secrets when PRs are opened from forks. That makes every third party contribution fail tests. The `pull_request_target` is designed for this use case and shouldn't have this issue.