### PR TITLE
Ensure Readability includes accordion/tab content

### DIFF
--- a/readability-server/readability-worker.js
+++ b/readability-server/readability-worker.js
@@ -22,6 +22,12 @@ WorkerPool.implementWorker((html, url, force = false) => {
     return null;
   }
 
+  // Include hidden accordions, tabs, disclosure areas, etc. in the text.
+  dom.window.document.querySelectorAll('[hidden]')
+    .forEach(node => node.removeAttribute('hidden'));
+
+  // Strip out other areas we know should not be included that Readability often
+  // fails to exclude.
   // XXX: Can we do this better?????
   dom.window.document.querySelectorAll('[class*="teaser"],[class*="related"]')
     .forEach(node => node.setAttribute('hidden', 'hidden'))


### PR DESCRIPTION
Between March 18 and 20th of this year, energy.gov switched from using custom JS and CSS to hide/collapse tabs and accordion panels to using the HTML `hidden` attribute. It also switched from showing all tab and accordion content until script hid it to hiding by default until script shows it. This change caused Readability to stop including the content on accordions and tabs in the page content for diffing and analysis, making it look like huge, crucial parts of many pages were removed to the analysis system, even though they were still there in the document.

This solves the issue by removing the `hidden` attribute from everything on the page, and only putting it back (or adding it for the first time) to the things we know we want to hide/strip from readability. This might wind up bringing a lot of new content into the "readable" view of the page, but in this case it's better to include than exclude.

This will probably affect a lot of other pages, but this should be a good change.

---

### Example

In Scanner, this change is fairly visible because the script to hide/show the accordions does not work: https://monitoring.envirodatagov.org/page/44eba971-5033-48d4-8214-b265b2771808/48713d1c-0de1-4eaf-8ce1-7f89d04bd35f..52b2f717-712d-407e-b433-3fd9263b3abc

In the “from” version, you can see the accordion panels are all open by default. In the “to” version, they are all hidden, but if you inspect the DOM, you can see that their content is unchanged. The comparison view doesn’t highlight the difference, because the differ includes content with the `hidden` attribute:

<img width="1557" height="727" alt="Screenshot of page comparison with accordion open vs closed by default on different dates" src="https://github.com/user-attachments/assets/5c0741e5-105d-4d57-baab-37e070e5f0ce" />

You can test run an analysis of this example change with:

```sh
 python generate_task_sheets.py \
    --output out \
    --after '2026-03-17T17:00:00Z' \
    --before '2026-03-24T17:00:00Z' \
    --threshold '0.25' \
    --pattern 'https://windexchange.energy.gov/projects/community-benefit-agreements'
```