### PR TITLE
Default to NO readability (also off for scheduled jobs)

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -38,7 +38,7 @@ on:
         description: 'Use Readability'
         required: false
         type: boolean
-        default: true
+        default: false
       upload_folder:
         description: 'Save to GDrive with this folder name'
         required: false
@@ -52,7 +52,7 @@ jobs:
       DEFAULT_THRESHOLD: '0.25'
       DEFAULT_FROM: ${{ github.event_name == 'schedule' && '268' || '240' }}
       DEFAULT_TO: '0'
-      USE_READABILITY: ${{ (inputs.readability || toJSON(inputs.readability) == 'null') && 'true' || 'false' }}
+      USE_READABILITY: ${{ inputs.readability && 'true' || 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Readability has caused complicated issues for a long time (see #9). After some recent issues analysts have run into, we’re switching it off for a while in favor of the homegrown alternative in the `normalization` module.

This code has been around for a while and we've tried it on and off, but it was mostly developed at the very end of Trump 1/beginning of Biden, when the analyst team had shrunk and there wasn't really a lot of bandwidth for messing with how stuff works. But it's time to give it a more serious go for at least a few weeks.