### PR TITLE
Run both deep (new) and old analysis on schedule

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -5,11 +5,8 @@ env:
 
 on:
   pull_request: {}
-  schedule:
-    # Tuesday at 4pm UTC/9am PT
-    - cron: '40 16 * * 2'
-  workflow_dispatch:
-    inputs:
+  workflow_call:
+    inputs: &standard_inputs
       threshold:
         description: 'Threshold'
         required: false
@@ -49,16 +46,18 @@ on:
         required: false
         type: string
         default: ''
+  workflow_dispatch:
+    inputs: *standard_inputs
 
 jobs:
   analyze:
     env:
-      DEFAULT_PATTERN: ${{ github.event_name == 'schedule' && '*' || '*justice.gov/*' }}
+      DEFAULT_PATTERN: '*justice.gov/*'
       DEFAULT_THRESHOLD: '0.25'
-      DEFAULT_FROM: ${{ github.event_name == 'schedule' && '268' || '240' }}
+      DEFAULT_FROM: '240'
       DEFAULT_TO: '0'
       USE_READABILITY: ${{ inputs.readability && 'true' || 'false' }}
-      DEEP: ${{ github.event_name == 'schedule' && 'true' || (inputs.deep && 'true' || 'false') }}
+      DEEP: ${{ inputs.deep && 'true' || 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -129,7 +128,7 @@ jobs:
           retention-days: 7
 
   upload:
-    if: inputs.upload_folder || github.event_name == 'schedule'
+    if: inputs.upload_folder
     needs:
       - analyze
     runs-on: ubuntu-latest
@@ -159,9 +158,6 @@ jobs:
         id: upload
         run: |
           FOLDER_NAME='${{ inputs.upload_folder }}'
-          if [ -z "${FOLDER_NAME}" ]; then
-            FOLDER_NAME="Scanner-sheets-$(date +'%Y-%m-%d')"
-          fi
           rclone copy --config rclone.conf out "gdrive-task-sheets:${FOLDER_NAME}"
           echo "folder_name=${FOLDER_NAME}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/analyze_scheduled.yml
+++ b/.github/workflows/analyze_scheduled.yml
@@ -1,0 +1,32 @@
+name: Weekly Analysis
+
+on:
+  schedule:
+    # Tuesday at 4pm UTC/9am PT
+    - cron: '40 16 * * 2'
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      folder_name: ${{ steps.folder_name.outputs.name }}
+    steps:
+      - name: Determine Folder Name
+        id: folder_name
+        run: |
+          FOLDER_NAME="Scanner-sheets-$(date +'%Y-%m-%d')"
+          echo "name=${FOLDER_NAME}" >> "$GITHUB_OUTPUT"
+
+  analyze:
+    needs:
+      - prepare
+    uses: ./.github/workflows/analyze.yml
+    with:
+      threshold: '0.25'
+      pattern: '*'
+      # tag:
+      from: '268'
+      to: '0'
+      readability: false
+      deep: true
+      upload_folder: '${{ needs.prepare.outputs.folder_name }}'

--- a/.github/workflows/analyze_scheduled_old.yml
+++ b/.github/workflows/analyze_scheduled_old.yml
@@ -1,0 +1,32 @@
+name: Weekly Analysis (Old)
+
+on:
+  schedule:
+    # Tuesday at 4pm UTC/9am PT
+    - cron: '40 16 * * 2'
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      folder_name: ${{ steps.folder_name.outputs.name }}
+    steps:
+      - name: Determine Folder Name
+        id: folder_name
+        run: |
+          FOLDER_NAME="Scanner-sheets-$(date +'%Y-%m-%d')--OLD"
+          echo "name=${FOLDER_NAME}" >> "$GITHUB_OUTPUT"
+
+  analyze:
+    needs:
+      - prepare
+    uses: ./.github/workflows/analyze.yml
+    with:
+      threshold: '0.25'
+      pattern: '*'
+      # tag:
+      from: '268'
+      to: '0'
+      readability: false
+      deep: false
+      upload_folder: '${{ needs.prepare.outputs.folder_name }}'


### PR DESCRIPTION
This moves the scheduling out of the `analyze.yml` workflow and makes the workflow callable. Then we have two separate scheduled workflows for the different automated analysis routines that call it. As a nice bonus, this simplifies the logic in `analyze.yml` and makes it a little easier to follow, since it can focus just on the inputs and not also on what the values should be for schedules.

This is a pattern I’ve started using in other projects, and it makes managing default values *much* easier and clearer.