### PR TITLE
Expand what counts as root path for error sinks

### DIFF
--- a/analyst_sheets/analyze.py
+++ b/analyst_sheets/analyze.py
@@ -328,12 +328,11 @@ def get_version_status(version: dict) -> int:
     # Redirects from a non-root page to the root are effectively 404s.
     url = version['url']
     redirects, _, _ = get_redirects(version)
-    if (
-        redirects
-        and not is_home_path(urlsplit(url).path)
-        and is_home_path(surt(redirects[-1]).split(')', 1)[1])
-    ):
-        return 404
+    if redirects and not is_home_path(urlsplit(url).path):
+        redirect_host, _, redirect_path = surt(redirects[-1]).partition(')')
+        original_host = surt(url).split(')', 1)[0]
+        if is_home_path(redirect_path) and redirect_host == original_host:
+            return 404
 
     # Special case for the EPA "signpost" page, where they redirected hundreds
     # of climate-related pages to instead of giving them 4xx status codes.

--- a/analyst_sheets/analyze.py
+++ b/analyst_sheets/analyze.py
@@ -330,8 +330,8 @@ def get_version_status(version: dict) -> int:
     redirects, _, _ = get_redirects(version)
     if (
         redirects
-        and urlsplit(url).path != '/'
-        and surt(urljoin(url, '/')) == surt(redirects[-1])
+        and not is_home_path(urlsplit(url).path)
+        and is_home_path(surt(redirects[-1]).split(')', 1)[1])
     ):
         return 404
 
@@ -520,12 +520,15 @@ def analyze_redirects(page, a, b):
     }
 
 
-ROOT_PAGE_PATTERN = re.compile(r'^/(index(\.\w+)?)?$')
+ROOT_PAGE_PATTERN = re.compile(r'^/((index|home)(\.\w+)?)?$')
 
 
-def is_home_page(page):
-    url_path = urlsplit(page['url']).path
-    return True if ROOT_PAGE_PATTERN.match(url_path) else False
+def is_home_path(path: str) -> bool:
+    return True if ROOT_PAGE_PATTERN.match(path) else False
+
+
+def is_home_page(page: dict) -> bool:
+    return is_home_path(urlsplit(page['url']).path)
 
 
 # Calculate a multiplier for priority based on a ratio representing the amount

--- a/analyst_sheets/tests/test_analyze.py
+++ b/analyst_sheets/tests/test_analyze.py
@@ -1,0 +1,77 @@
+from ..analyze import get_version_status
+
+
+EMPTY_HTML = """
+    <!doctype html>
+    <html lang="en">
+        <head>
+            <meta charset="utf-8">
+            <title>Hello</title>
+        </head>
+        <body>
+        </body>
+    </html>
+"""
+
+
+class TestGetVersionStatus:
+    def test_redirects_are_ok(self):
+        assert 200 == get_version_status({
+            'url': 'https://hazards.fema.gov/nri/take-action',
+            'status': 200,
+            'source_metadata': {
+                'statuses': [
+                    '301',
+                    '200'
+                ],
+                'redirects': [
+                    'https://hazards.fema.gov/nri/take-action',
+                    'https://www.fema.gov/emergency-managers/practitioners/resilience-analysis-and-planning-tool',
+                ],
+                'redirected_url': 'https://www.fema.gov/emergency-managers/practitioners/resilience-analysis-and-planning-tool',
+            },
+            'title': 'Resilience Analysis and Planning Tool (RAPT) | FEMA.gov',
+            'headers': {},
+            '_body_text': EMPTY_HTML,
+        })
+
+    def test_redirects_to_root_path_are_404(self):
+        # Redirect to "/".
+        assert 404 == get_version_status({
+            'url': 'https://waterdata.usgs.gov/nwis',
+            'status': 200,
+            'source_metadata': {
+                'statuses': [
+                    '301',
+                    '200'
+                ],
+                'redirects': [
+                    'https://waterdata.usgs.gov/nwis',
+                    'https://waterdata.usgs.gov/',
+                ],
+                'redirected_url': 'https://waterdata.usgs.gov/',
+            },
+            'title': 'USGS Water Data for the Nation',
+            'headers': {},
+            '_body_text': EMPTY_HTML,
+        })
+
+        # Redirect to root-like path.
+        assert 404 == get_version_status({
+            'url': 'https://eta.lbl.gov/justice-40',
+            'status': 200,
+            'source_metadata': {
+                'statuses': [
+                    '301',
+                    '200'
+                ],
+                'redirects': [
+                    'https://eta.lbl.gov/justice-40',
+                    'https://eta.lbl.gov/home',
+                ],
+                'redirected_url': 'https://eta.lbl.gov/home',
+            },
+            'title': 'Energy Technologies Area | Energy Technologies Area',
+            'headers': {},
+            '_body_text': EMPTY_HTML,
+        })

--- a/analyst_sheets/tests/test_analyze.py
+++ b/analyst_sheets/tests/test_analyze.py
@@ -75,3 +75,24 @@ class TestGetVersionStatus:
             'headers': {},
             '_body_text': EMPTY_HTML,
         })
+
+    def test_redirects_to_root_across_domains_are_ok(self):
+        # Redirect to "/".
+        assert 200 == get_version_status({
+            'url': 'https://waterdata.usgs.gov/nwis',
+            'status': 200,
+            'source_metadata': {
+                'statuses': [
+                    '301',
+                    '200'
+                ],
+                'redirects': [
+                    'https://waterdata.usgs.gov/nwis',
+                    'https://www.usgs.gov/',
+                ],
+                'redirected_url': 'https://www.usgs.gov/',
+            },
+            'title': 'USGS Water Data for the Nation',
+            'headers': {},
+            '_body_text': EMPTY_HTML,
+        })


### PR DESCRIPTION
Based on a conversation about a problematic analysis result with one of the analysts today.

It generally makes sense that if we consider `/index.html` to be a home page for other parts of the analysis, we should consider the same for what counts as the home page in effective status code calculations (we consider a redirect from a non-home to a home page of the same domain to be an error sink, and effectively a 404).

Also, `/home` is often used (and was in this case) like `/index`, so this updates the `is_home_page` function to include that.

Need to also update this over in web-monitoring-db.