### PR TITLE
Tighten analysis timeframe for status sheets

### DIFF
--- a/generate_status_sheet.py
+++ b/generate_status_sheet.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 def main(url: str = '*', tags: list[str] = []) -> None:
     before = datetime.now(tz=timezone.utc)
-    after = before - timedelta(days=14)
+    after = before - timedelta(days=7)
 
     pages = list_all_pages(url, after=None, before=None, tags=tags, total=True)
     count = next(pages)


### PR DESCRIPTION
When we generate the current status sheets, we look back over a timeframe of 14 days for valid captures. This comes from a time when our captures were less consistent and reliable, and is a really long timeframe to look back! It's time to tighten this down a bit.

Based on the results of this month’s status sheets from this morning, which would have had more accurate results if this was in place.