### PR TITLE
Categorize and summarize redirect changes

### DIFF
--- a/analyst_sheets/analyze.py
+++ b/analyst_sheets/analyze.py
@@ -11,6 +11,7 @@ import os.path
 import re
 from surt import surt
 import traceback
+from typing import Any
 from urllib.parse import urljoin, urlsplit
 from web_monitoring_diff import (html_source_diff, html_text_diff,
                                  links_diff_json)
@@ -503,7 +504,47 @@ def get_redirects(version) -> tuple[list[str], list[str], str | None]:
     return combined, server, client
 
 
-def analyze_redirects(page, a, b):
+# Used for splitting a SURT URL into components relevant to redirect analysis.
+SURT_COMPARISON_SPLIT = re.compile(
+    r"""
+    ^
+    (?P<host>[^)]+)\)  # Host - everything up to the first ")"
+    (?P<path>[^?]*?)/  # Path without last component (everything up to the
+                       #   final "/" before "?" or end)
+    (?P<filename>      # Last path component + optional querystring
+        [^/?]*
+        (?:\?.*)?
+    )
+    $
+    """,
+    re.VERBOSE
+)
+
+
+def url_change_type(a: str, b: str) -> str | None:
+    """
+    Compare two URLs and return a string indicating how they meaningfully
+    differ. If the URLs are effectively the same, this will return ``None``.
+    This considers URLs very loosely, ignoring protocol, case, some
+    querystings, etc.
+    """
+    surt_a = surt(a)
+    surt_b = surt(b)
+    if surt_a == surt_b:
+        return None
+
+    host_a, path_a, _filename_a = SURT_COMPARISON_SPLIT.match(surt_a).groups()
+    host_b, path_b, _filename_b = SURT_COMPARISON_SPLIT.match(surt_b).groups()
+
+    if host_a != host_b:
+        return 'domain'
+    elif path_a != path_b:
+        return 'path'
+    else:
+        return 'name'
+
+
+def analyze_redirects(page, a, b) -> dict[str, Any]:
     a_all, a_server, a_client = get_redirects(a)
     b_all, b_server, b_client = get_redirects(b)
 
@@ -515,11 +556,14 @@ def analyze_redirects(page, a, b):
     elif not a_client and b_client:
         is_client_redirect = 'became redirect'
 
-    final_a = surt(a_all[-1] if len(a_all) else a['url'], reverse_ipaddr=False)
-    final_b = surt(b_all[-1] if len(b_all) else b['url'], reverse_ipaddr=False)
+    change_type = url_change_type(
+        a_all[-1] if len(a_all) else a['url'],
+        b_all[-1] if len(b_all) else b['url'],
+    )
 
     return {
-        'changed': final_a != final_b,
+        'change_type': change_type,
+        'changed': change_type is not None,
         'client_changed': a_client != b_client,
         'is_client_redirect': is_client_redirect,
         'a_server': a_server,
@@ -616,8 +660,11 @@ def analyze_page(page, after, before, use_readability=True):
         priority *= page_status_factor(page, a, b)
 
     redirect_analysis = analyze_redirects(page, a, b)
-    if redirect_analysis['changed']:
-        priority += 0.25
+    if redirect_analysis['change_type'] == 'domain':
+        priority += 1
+    elif redirect_analysis['change_type'] == 'path':
+        priority += 0.5
+    # Other destination change types are not prioritized (name, no change).
 
     # Ensure priority at least matches baseline.
     priority = max(priority, baseline)

--- a/analyst_sheets/sheets.py
+++ b/analyst_sheets/sheets.py
@@ -144,7 +144,7 @@ def format_row(page, timeframe, analysis, error, index, name, timestamp, overall
             format(analysis['links']['diff_ratio'], '.3f'),
             analysis['links']['removed_self_link'],
             analysis['redirect']['is_client_redirect'] or '',
-            analysis['redirect']['changed'] or '',
+            analysis['redirect']['change_type'] or '',
             format_redirects(analysis['redirect']['a_server'], analysis['redirect']['a_client']),
             format_redirects(analysis['redirect']['b_server'], analysis['redirect']['b_client']),
         ])

--- a/generate_task_sheets.py
+++ b/generate_task_sheets.py
@@ -439,7 +439,7 @@ def write_redirect_change_summary(output_path: Path, results: Iterable[PageAnaly
         ])
         sheet_groups = group_by_tags(results, ['category:', 'news', '2l-domain:'])
         for sheet_name, sheet_results in sheet_groups.items():
-            category, domain = sheet_name.rsplit('--', 1)
+            category, _, domain = sheet_name.rpartition('--')
             for result in sorted(sheet_results, key=lambda r: r.page['url']):
                 analysis = result.overall and result.overall['redirect']
                 if not analysis or not analysis['change_type']:
@@ -495,7 +495,7 @@ def write_redirect_current_summary(output_path: Path, results: Iterable[PageAnal
         ])
         sheet_groups = group_by_tags(results, ['category:', 'news', '2l-domain:'])
         for sheet_name, sheet_results in sheet_groups.items():
-            category, domain = sheet_name.rsplit('--', 1)
+            category, _, domain = sheet_name.rpartition('--')
             for result in sorted(sheet_results, key=lambda r: r.page['url']):
                 if not result.overall:
                     continue

--- a/generate_task_sheets.py
+++ b/generate_task_sheets.py
@@ -420,6 +420,109 @@ def write_sheets(output_path: Path, results: Iterable[PageAnalysisResult], deep:
         write_csv(output_path, sheet_name, sorted_results, deep)
 
 
+def write_redirect_change_summary(output_path: Path, results: Iterable[PageAnalysisResult]) -> None:
+    # TODO: This is a bit quick-n-dirty; should probably move to sheets.py.
+    import csv
+    from analyst_sheets.sheets import format_status
+    with (output_path / '_redirects-changed.csv').open('w') as file:
+        writer = csv.writer(file)
+        writer.writerow([
+            'UUID',
+            'Category',
+            'Domain',
+            'Status',
+            'Redirect Type',
+            'Monitored URL',
+            'Redirect Old vs New',
+            'Redirect Old',
+            'Redirect New',
+        ])
+        sheet_groups = group_by_tags(results, ['category:', 'news', '2l-domain:'])
+        for sheet_name, sheet_results in sheet_groups.items():
+            category, domain = sheet_name.rsplit('--', 1)
+            for result in sorted(sheet_results, key=lambda r: r.page['url']):
+                analysis = result.overall and result.overall['redirect']
+                if not analysis or not analysis['change_type']:
+                    continue
+
+                change_type = analysis['change_type']
+                a = result.timeframe[-1]
+                b = result.timeframe[0]
+                a_all = [
+                    url
+                    for url in [*analysis['a_server'], analysis['a_client']]
+                    if url
+                ]
+                b_all = [
+                    url
+                    for url in [*analysis['b_server'], analysis['b_client']]
+                    if url
+                ]
+                a_url = a_all[-1] if len(a_all) else a['url']
+                b_url = b_all[-1] if len(b_all) else b['url']
+
+                writer.writerow([
+                    result.page['uuid'],
+                    category,
+                    domain,
+                    format_status(result.overall['status_b']),
+                    change_type,
+                    b['url'],
+                    f'{a_url}\n{b_url}',
+                    a_url,
+                    b_url,
+                ])
+
+
+def write_redirect_current_summary(output_path: Path, results: Iterable[PageAnalysisResult]) -> None:
+    # TODO: This is a bit quick-n-dirty; should probably move to sheets.py.
+    import csv
+    from analyst_sheets.analyze import get_redirects, url_change_type
+    from analyst_sheets.sheets import format_redirects, format_status
+    with (output_path / '_redirects-current.csv').open('w') as file:
+        writer = csv.writer(file)
+        writer.writerow([
+            'UUID',
+            'Category',
+            'Domain',
+            'Status',
+            'Redirect Type',
+            'Monitored vs Redirected',
+            'Formatted Redirects',
+            'Monitored URL',
+            'Redirected URL',
+            'All Redirects',
+        ])
+        sheet_groups = group_by_tags(results, ['category:', 'news', '2l-domain:'])
+        for sheet_name, sheet_results in sheet_groups.items():
+            category, domain = sheet_name.rsplit('--', 1)
+            for result in sorted(sheet_results, key=lambda r: r.page['url']):
+                if not result.overall:
+                    continue
+
+                version_end = result.timeframe[0]
+                redirects, redirect_server, redirect_client = get_redirects(version_end)
+                if not redirects:
+                    continue
+
+                change_type = url_change_type(version_end['url'], redirects[-1])
+                if not change_type:
+                    continue
+
+                writer.writerow([
+                    result.page['uuid'],
+                    category,
+                    domain,
+                    format_status(result.overall['status_b']),
+                    change_type,
+                    f"{version_end['url']}\n{redirects[-1]}",
+                    '\n'.join(redirects),
+                    version_end['url'],
+                    redirects[-1],
+                    format_redirects(redirect_server, redirect_client),
+                ])
+
+
 def main(pattern=None, tags=None, after=None, before=None, output_path=None, threshold=0, deep=False, verbose=False, use_readability=True):
     with QuitSignal((signal.SIGINT,)) as cancel:
         # Make sure we can actually output the results before getting started.
@@ -482,6 +585,8 @@ def main(pattern=None, tags=None, after=None, before=None, output_path=None, thr
         ]
         if output_path:
             write_sheets(output_path, filtered, deep)
+            write_redirect_change_summary(output_path, results)
+            write_redirect_current_summary(output_path, results)
         else:
             for result in filtered:
                 pretty_print_analysis(result, output=tqdm)


### PR DESCRIPTION
Based on discussions with analysts, we need to do a better job breaking down redirect changes and determining whether the change was worth paying special attention to.

This attempts to solve the issue by categorizing redirect changes as None, "domain", "path", or "name" (final path component + querystring), based on what part of the URL changed. We only prioritize "domain" or "path" changes.

This *also* outputs two new summary sheets (a little janky, I expect these to change), since another lesson here is that analysis of what to do for redirects may be a special concern for just some analysts. These summary sheets let them cover this task in a more focused way across all pages, rather than the info being buried in a zillion different sheets.